### PR TITLE
PYCO-12: Raise RuntimeError when accessing query metadata prematurely

### DIFF
--- a/acouchbase_columnar/protocol/query.py
+++ b/acouchbase_columnar/protocol/query.py
@@ -70,10 +70,12 @@ class _AsyncQueryStreamingExecutor(StreamingExecutor):
             return
         self._query_iter.cancel()
 
-    def get_metadata(self) -> Optional[QueryMetadata]:
+    def get_metadata(self) -> QueryMetadata:
         # TODO:  Maybe not needed if we get metadata automatically?
         if self._metadata is None:
             self.set_metadata()
+            if self._metadata is None:
+                raise RuntimeError('Query metadata is only available after all rows have been iterated.')
         return self._metadata
 
     def handle_exception(self, ex: Exception) -> NoReturn:
@@ -97,8 +99,7 @@ class _AsyncQueryStreamingExecutor(StreamingExecutor):
         if isinstance(query_metadata, CoreColumnarException):
             raise ErrorMapper.build_exception(query_metadata)
         if query_metadata is None:
-            # TODO:  better exception
-            raise ColumnarException.from_message('Metadata unavailable.')
+            return
         self._metadata = QueryMetadata(query_metadata)
 
     async def submit_query(self) -> None:

--- a/couchbase_columnar/common/result.py
+++ b/couchbase_columnar/common/result.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 from typing import (Any,
                     AsyncIterable,
                     Iterable,
-                    List,
-                    Optional)
+                    List)
 
 from couchbase_columnar.common.core.result import QueryResult as QueryResult
 from couchbase_columnar.common.query import QueryMetadata
@@ -47,11 +46,14 @@ class BlockingQueryResult(QueryResult):
         """
         return BlockingIterator(self._executor).get_all_rows()
 
-    def metadata(self) -> Optional[QueryMetadata]:
+    def metadata(self) -> QueryMetadata:
         """The meta-data which has been returned by the query.
 
         Returns:
             :class:`~couchbase_columnar.query.QueryMetadata`: An instance of :class:`~couchbase_columnar.query.QueryMetadata`.
+
+        Raises:
+            :class:`RuntimeError`: When the metadata is not available. Metadata is only available once all rows have been iterated.
         """  # noqa: E501
         return self._executor.get_metadata()
 
@@ -92,11 +94,14 @@ class AsyncQueryResult(QueryResult):
         """
         return await AsyncIterator(self._executor).get_all_rows()
 
-    def metadata(self) -> Optional[QueryMetadata]:
+    def metadata(self) -> QueryMetadata:
         """The meta-data which has been returned by the query.
 
         Returns:
             :class:`~couchbase_columnar.query.QueryMetadata`: An instance of :class:`~couchbase_columnar.query.QueryMetadata`.
+
+        Raises:
+            :class:`RuntimeError`: When the metadata is not available. Metadata is only available once all rows have been iterated.
         """  # noqa: E501
         return self._executor.get_metadata()
 

--- a/couchbase_columnar/common/streaming.py
+++ b/couchbase_columnar/common/streaming.py
@@ -21,7 +21,6 @@ from typing import (Any,
                     Coroutine,
                     List,
                     NoReturn,
-                    Optional,
                     Union)
 
 if sys.version_info < (3, 9):
@@ -52,7 +51,7 @@ class StreamingExecutor(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_metadata(self) -> Optional[QueryMetadata]:
+    def get_metadata(self) -> QueryMetadata:
         raise NotImplementedError
 
     @abstractmethod


### PR DESCRIPTION
## Motivation

The Streaming RFC requires that we raise a platform-idiomatic "illegal state" exception when attempting to access the query metadata before it becomes available (i.e. before all rows have been iterated).

Currently, the SDK either returns `None` (when the iteration had not started) or a `ColumnarException` when accessing the metadata mid-iteration.

## Changes

* Raise a `RuntimeError` when accessing the metadata before all rows have been iterated
* Update function signatures for `metadata()` to make the result non-optional

## Results

Newly added tests pass. Relevant FIT test passes.
