### PR TITLE
PYCO-22: Do not allow negative timeout values

### DIFF
--- a/acouchbase_columnar/tests/options_t.py
+++ b/acouchbase_columnar/tests/options_t.py
@@ -50,6 +50,8 @@ class ClusterOptionsTestSuite:
         'test_security_options_kwargs',
         'test_timeout_options',
         'test_timeout_options_kwargs',
+        'test_timeout_options_must_be_positive',
+        'test_timeout_options_must_be_positive_kwargs',
     ]
 
     @pytest.mark.parametrize('opts, expected_opts',
@@ -262,6 +264,36 @@ class ClusterOptionsTestSuite:
         cred = Credential.from_username_and_password('Administrator', 'password')
         client = _ClientAdapter('couchbases://localhost', cred, ClusterOptions(), event_loop, **opts)
         assert expected_opts == client.connection_details.cluster_options.get('timeout_options')
+
+    @pytest.mark.parametrize('opts',
+                             [{'connect_timeout': timedelta(seconds=-1)},
+                              {'dispatch_timeout': timedelta(seconds=-1)},
+                              {'dns_srv_timeout': timedelta(seconds=-1)},
+                              {'management_timeout': timedelta(seconds=-1)},
+                              {'query_timeout': timedelta(seconds=-1)},
+                              {'resolve_timeout': timedelta(seconds=-1)},
+                              {'socket_connect_timeout': timedelta(seconds=-1)}])
+    def test_timeout_options_must_be_positive(self, opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        with pytest.raises(ValueError):
+            _ClientAdapter('couchbases://localhost',
+                           cred,
+                           ClusterOptions(timeout_options=TimeoutOptions(**opts)))
+
+    @pytest.mark.parametrize('opts',
+                             [{'connect_timeout': timedelta(seconds=-1)},
+                              {'dispatch_timeout': timedelta(seconds=-1)},
+                              {'dns_srv_timeout': timedelta(seconds=-1)},
+                              {'management_timeout': timedelta(seconds=-1)},
+                              {'query_timeout': timedelta(seconds=-1)},
+                              {'resolve_timeout': timedelta(seconds=-1)},
+                              {'socket_connect_timeout': timedelta(seconds=-1)}])
+    def test_timeout_options_must_be_positive_kwargs(self,
+                                                     event_loop: AbstractEventLoop,
+                                                     opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        with pytest.raises(ValueError):
+            _ClientAdapter('couchbases://localhost', cred, ClusterOptions(), event_loop, **opts)
 
 
 class ClusterOptionsTests(ClusterOptionsTestSuite):

--- a/acouchbase_columnar/tests/query_options_t.py
+++ b/acouchbase_columnar/tests/query_options_t.py
@@ -54,7 +54,9 @@ class QueryOptionsTestSuite:
         'test_options_scan_consistency',
         'test_options_scan_consistency_kwargs',
         'test_options_timeout',
-        'test_options_timeout_kwargs'
+        'test_options_timeout_kwargs',
+        'test_options_timeout_must_be_positive',
+        'test_options_timeout_must_be_positive_kwargs'
     ]
 
     @pytest.fixture(scope='class')
@@ -276,6 +278,22 @@ class QueryOptionsTestSuite:
         assert req.options == exp_opts
         assert req.database_name == query_ctx.database_name
         assert req.scope_name == query_ctx.scope_name
+
+    def test_options_timeout_must_be_positive(self,
+                                              query_statment: str,
+                                              request_builder: Union[ClusterRequestBuilder, ScopeRequestBuilder]
+                                              ) -> None:
+        q_opts = QueryOptions(timeout=timedelta(seconds=-1))
+        with pytest.raises(ValueError):
+            request_builder.build_query_request(query_statment, q_opts)
+
+    def test_options_timeout_must_be_positive_kwargs(self,
+                                                     query_statment: str,
+                                                     request_builder: Union[ClusterRequestBuilder, ScopeRequestBuilder]
+                                                     ) -> None:
+        kwargs = {'timeout': timedelta(seconds=-1)}
+        with pytest.raises(ValueError):
+            request_builder.build_query_request(query_statment, **kwargs)
 
 
 class ClusterQueryOptionsTests(QueryOptionsTestSuite):

--- a/couchbase_columnar/common/core/utils.py
+++ b/couchbase_columnar/common/core/utils.py
@@ -40,6 +40,8 @@ def is_null_or_empty(value: Optional[str]) -> bool:
 def timedelta_as_microseconds(duration: timedelta) -> int:
     if duration and not isinstance(duration, timedelta):
         raise ValueError(f"Expected timedelta instead of {duration}")
+    if duration.total_seconds() < 0:
+        raise ValueError('Timeout must be non-negative.')
     return int(duration.total_seconds() * 1e6 if duration else 0)
 
 
@@ -49,8 +51,12 @@ def to_microseconds(value: Union[timedelta, float, int]) -> int:
     if not value:
         total_us = 0
     elif isinstance(value, timedelta):
+        if value.total_seconds() < 0:
+            raise ValueError('Timeout must be non-negative.')
         total_us = int(value.total_seconds() * 1e6)
     else:
+        if value < 0:
+            raise ValueError('Timeout must be non-negative.')
         total_us = int(value * 1e6)
 
     return total_us

--- a/couchbase_columnar/tests/options_t.py
+++ b/couchbase_columnar/tests/options_t.py
@@ -49,6 +49,8 @@ class ClusterOptionsTestSuite:
         'test_security_options_kwargs',
         'test_timeout_options',
         'test_timeout_options_kwargs',
+        'test_timeout_options_must_be_positive',
+        'test_timeout_options_must_be_positive_kwargs',
     ]
 
     @pytest.mark.parametrize('opts, expected_opts',
@@ -248,6 +250,34 @@ class ClusterOptionsTestSuite:
         cred = Credential.from_username_and_password('Administrator', 'password')
         client = _ClientAdapter('couchbases://localhost', cred, **opts)
         assert expected_opts == client.connection_details.cluster_options.get('timeout_options')
+
+    @pytest.mark.parametrize('opts',
+                             [{'connect_timeout': timedelta(seconds=-1)},
+                              {'dispatch_timeout': timedelta(seconds=-1)},
+                              {'dns_srv_timeout': timedelta(seconds=-1)},
+                              {'management_timeout': timedelta(seconds=-1)},
+                              {'query_timeout': timedelta(seconds=-1)},
+                              {'resolve_timeout': timedelta(seconds=-1)},
+                              {'socket_connect_timeout': timedelta(seconds=-1)}])
+    def test_timeout_options_must_be_positive(self, opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        with pytest.raises(ValueError):
+            _ClientAdapter('couchbases://localhost',
+                           cred,
+                           ClusterOptions(timeout_options=TimeoutOptions(**opts)))
+
+    @pytest.mark.parametrize('opts',
+                             [{'connect_timeout': timedelta(seconds=-1)},
+                              {'dispatch_timeout': timedelta(seconds=-1)},
+                              {'dns_srv_timeout': timedelta(seconds=-1)},
+                              {'management_timeout': timedelta(seconds=-1)},
+                              {'query_timeout': timedelta(seconds=-1)},
+                              {'resolve_timeout': timedelta(seconds=-1)},
+                              {'socket_connect_timeout': timedelta(seconds=-1)}])
+    def test_timeout_options_must_be_positive_kwargs(self, opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        with pytest.raises(ValueError):
+            _ClientAdapter('couchbases://localhost', cred, **opts)
 
 
 class ClusterOptionsTests(ClusterOptionsTestSuite):

--- a/couchbase_columnar/tests/query_options_t.py
+++ b/couchbase_columnar/tests/query_options_t.py
@@ -54,7 +54,9 @@ class QueryOptionsTestSuite:
         'test_options_scan_consistency',
         'test_options_scan_consistency_kwargs',
         'test_options_timeout',
-        'test_options_timeout_kwargs'
+        'test_options_timeout_kwargs',
+        'test_options_timeout_must_be_positive',
+        'test_options_timeout_must_be_positive_kwargs'
     ]
 
     @pytest.fixture(scope='class')
@@ -276,6 +278,22 @@ class QueryOptionsTestSuite:
         assert req.options == exp_opts
         assert req.database_name == query_ctx.database_name
         assert req.scope_name == query_ctx.scope_name
+
+    def test_options_timeout_must_be_positive(self,
+                                              query_statment: str,
+                                              request_builder: Union[ClusterRequestBuilder, ScopeRequestBuilder]
+                                              ) -> None:
+        q_opts = QueryOptions(timeout=timedelta(seconds=-1))
+        with pytest.raises(ValueError):
+            request_builder.build_query_request(query_statment, q_opts)
+
+    def test_options_timeout_must_be_positive_kwargs(self,
+                                                     query_statment: str,
+                                                     request_builder: Union[ClusterRequestBuilder, ScopeRequestBuilder]
+                                                     ) -> None:
+        kwargs = {'timeout': timedelta(seconds=-1)}
+        with pytest.raises(ValueError):
+            request_builder.build_query_request(query_statment, **kwargs)
 
 
 class ClusterQueryOptionsTests(QueryOptionsTestSuite):


### PR DESCRIPTION
Changes
=======
* Raise a ValueError if a negative timeout is provided
* Add tests to confirm functionality