### PR TITLE
PYCO-24: Do not set SecurityOptions.trust_only_capella to default if …

### DIFF
--- a/couchbase_columnar/common/options.py
+++ b/couchbase_columnar/common/options.py
@@ -143,7 +143,7 @@ class SecurityOptions(SecurityOptionsBase):
         Returns:
             :class:`~couchbase_columnar.common.options.SecurityOptions`
         """  # noqa: E501
-        return cls(trust_only_pem_file=pem_file)
+        return cls(trust_only_capella=False, trust_only_pem_file=pem_file)
 
     @classmethod
     def trust_only_pem_str(cls, pem_str: str) -> SecurityOptions:
@@ -156,7 +156,7 @@ class SecurityOptions(SecurityOptionsBase):
         Returns:
             :class:`~couchbase_columnar.common.options.SecurityOptions`
         """  # noqa: E501
-        return cls(trust_only_pem_str=pem_str)
+        return cls(trust_only_capella=False, trust_only_pem_str=pem_str)
 
     @classmethod
     def trust_only_certificates(cls, certificates: List[str]) -> SecurityOptions:
@@ -169,7 +169,7 @@ class SecurityOptions(SecurityOptionsBase):
         Returns:
             :class:`~couchbase_columnar.common.options.SecurityOptions`
         """  # noqa: E501
-        return cls(trust_only_certificates=certificates)
+        return cls(trust_only_capella=False, trust_only_certificates=certificates)
 
     @classmethod
     def trust_only_platform(cls) -> SecurityOptions:
@@ -179,7 +179,7 @@ class SecurityOptions(SecurityOptionsBase):
         Returns:
             :class:`~couchbase_columnar.common.options.SecurityOptions`
         """
-        return cls(trust_only_platform=True)
+        return cls(trust_only_capella=False, trust_only_platform=True)
 
 
 class TimeoutOptions(TimeoutOptionsBase):

--- a/couchbase_columnar/tests/options_t.py
+++ b/couchbase_columnar/tests/options_t.py
@@ -46,7 +46,10 @@ class ClusterOptionsTestSuite:
         'test_options_deserializer',
         'test_options_deserializer_kwargs',
         'test_security_options',
+        'test_security_options_classmethods',
         'test_security_options_kwargs',
+        'test_security_options_invalid',
+        'test_security_options_invalid_kwargs',
         'test_timeout_options',
         'test_timeout_options_kwargs',
         'test_timeout_options_must_be_positive',
@@ -149,13 +152,19 @@ class ClusterOptionsTestSuite:
                               ({'trust_only_capella': True},
                                {'trust_only_capella': True}),
                               ({'trust_only_pem_file': CONFIG_FILE},
-                               {'trust_only_pem_file': CONFIG_FILE}),
+                               {'trust_only_pem_file': CONFIG_FILE,
+                                'trust_only_capella': False}),
                               ({'trust_only_pem_str': 'BEGIN CERTIFICATIE...'},
-                               {'trust_only_pem_str': 'BEGIN CERTIFICATIE...'}),
+                               {'trust_only_pem_str': 'BEGIN CERTIFICATIE...',
+                                'trust_only_capella': False}),
                               ({'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...']},
-                               {'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...']}),
+                               {'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...'],
+                                'trust_only_capella': False}),
                               ({'verify_server_certificate': False},
                                {'verify_server_certificate': False}),
+                              ({'trust_only_platform': True},
+                               {'trust_only_platform': True,
+                                'trust_only_capella': False}),
                               ({'cipher_suites': ['TLS_AES_256_GCM_SHA384',
                                                   'TLS_CHACHA20_POLY1305_SHA256',
                                                   'TLS_AES_128_GCM_SHA256']},
@@ -171,17 +180,47 @@ class ClusterOptionsTestSuite:
         assert expected_opts == client.connection_details.cluster_options.get('security_options')
 
     @pytest.mark.parametrize('opts, expected_opts',
+                             [(SecurityOptions.trust_only_capella(),
+                               {'trust_only_capella': True}),
+                              (SecurityOptions.trust_only_pem_file(CONFIG_FILE),
+                               {'trust_only_pem_file': CONFIG_FILE,
+                                'trust_only_capella': False}),
+                              (SecurityOptions.trust_only_pem_str('BEGIN CERTIFICATIE...'),
+                               {'trust_only_pem_str': 'BEGIN CERTIFICATIE...',
+                                'trust_only_capella': False}),
+                              (SecurityOptions.trust_only_certificates(['BEGIN CERTIFICATIE...',
+                                                                        'BEGIN CERTIFICATIE...']),
+                               {'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...'],
+                                'trust_only_capella': False}),
+                              (SecurityOptions.trust_only_platform(),
+                               {'trust_only_platform': True,
+                                'trust_only_capella': False}),
+                              ])
+    def test_security_options_classmethods(self, opts: SecurityOptions, expected_opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        client = _ClientAdapter('couchbases://localhost',
+                                cred,
+                                ClusterOptions(security_options=opts))
+        assert expected_opts == client.connection_details.cluster_options.get('security_options')
+
+    @pytest.mark.parametrize('opts, expected_opts',
                              [({}, None),
                               ({'trust_only_capella': True},
                                {'trust_only_capella': True}),
                               ({'trust_only_pem_file': CONFIG_FILE},
-                               {'trust_only_pem_file': CONFIG_FILE}),
+                               {'trust_only_pem_file': CONFIG_FILE,
+                                'trust_only_capella': False}),
                               ({'trust_only_pem_str': 'BEGIN CERTIFICATIE...'},
-                               {'trust_only_pem_str': 'BEGIN CERTIFICATIE...'}),
+                               {'trust_only_pem_str': 'BEGIN CERTIFICATIE...',
+                                'trust_only_capella': False}),
                               ({'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...']},
-                               {'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...']}),
+                               {'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...'],
+                                'trust_only_capella': False}),
                               ({'verify_server_certificate': False},
                                {'verify_server_certificate': False}),
+                              ({'trust_only_platform': True},
+                               {'trust_only_platform': True,
+                                'trust_only_capella': False}),
                               ({'cipher_suites': ['TLS_AES_256_GCM_SHA384',
                                                   'TLS_CHACHA20_POLY1305_SHA256',
                                                   'TLS_AES_128_GCM_SHA256']},
@@ -193,6 +232,38 @@ class ClusterOptionsTestSuite:
         cred = Credential.from_username_and_password('Administrator', 'password')
         client = _ClientAdapter('couchbases://localhost', cred, **opts)
         assert expected_opts == client.connection_details.cluster_options.get('security_options')
+
+    @pytest.mark.parametrize('opts',
+                             [{'trust_only_capella': True,
+                               'trust_only_pem_file': CONFIG_FILE},
+                              {'trust_only_capella': True,
+                               'trust_only_pem_str': 'BEGIN CERTIFICATIE...'},
+                              {'trust_only_capella': True,
+                               'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...']},
+                              {'trust_only_capella': True,
+                               'trust_only_platform': True},
+                              ])
+    def test_security_options_invalid(self, opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        with pytest.raises(ValueError):
+            _ClientAdapter('couchbases://localhost',
+                           cred,
+                           ClusterOptions(security_options=SecurityOptions(**opts)))
+
+    @pytest.mark.parametrize('opts',
+                             [{'trust_only_capella': True,
+                               'trust_only_pem_file': CONFIG_FILE},
+                              {'trust_only_capella': True,
+                               'trust_only_pem_str': 'BEGIN CERTIFICATIE...'},
+                              {'trust_only_capella': True,
+                               'trust_only_certificates': ['BEGIN CERTIFICATIE...', 'BEGIN CERTIFICATIE...']},
+                              {'trust_only_capella': True,
+                               'trust_only_platform': True},
+                              ])
+    def test_security_options_invalid_kwargs(self, opts: Dict[str, object]) -> None:
+        cred = Credential.from_username_and_password('Administrator', 'password')
+        with pytest.raises(ValueError):
+            _ClientAdapter('couchbases://localhost', cred, **opts)
 
     @pytest.mark.parametrize('opts, expected_opts',
                              [({}, None),


### PR DESCRIPTION
…other

SecurityOption set

Changes
=======
* For SecurityOptions that are specified to clear other SecurityOptions (trust_only_pem_file, trust_only_pem_str, trust_only_certificates and trust_only_platform) the trust_only_capella Security option is set to False to the default value (True) is not used in the C++ core
* Only allow one of the SecurityOptions (all but, verify_server_certificate and cipher_suites) to be set at one time.
* Add tests to confirm functionality