### PR TITLE
PYCO-21: Add Python 3.12 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,22 @@ set(COUCHBASE_CXX_CLIENT_COLUMNAR
 set(COUCHBASE_CXX_CLIENT_PYTHON_WARNINGS
     ON
     CACHE INTERNAL "")
-set(COUCHBASE_CXX_CLIENT_BUILD_TESTS
+set(COUCHBASE_CXX_CLIENT_BUILD_STATIC
+    ON
+    CACHE BOOL "" FORCE)
+set(COUCHBASE_CXX_CLIENT_BUILD_SHARED
+    OFF
+    CACHE BOOL "" FORCE)
+set(COUCHBASE_CXX_CLIENT_BUILD_INSTALL
+    OFF
+    CACHE BOOL "" FORCE)
+set(COUCHBASE_CXX_CLIENT_BUILD_DOCS
     OFF
     CACHE BOOL "" FORCE)
 set(COUCHBASE_CXX_CLIENT_BUILD_EXAMPLES
+    OFF
+    CACHE BOOL "" FORCE)
+set(COUCHBASE_CXX_CLIENT_BUILD_TESTS
     OFF
     CACHE BOOL "" FORCE)
 set(COUCHBASE_CXX_CLIENT_BUILD_TOOLS
@@ -160,7 +172,9 @@ endif()
 add_subdirectory(deps/couchbase-cxx-client)
 
 set(COUCHBASE_CXX_BINARY_DIR "${CMAKE_BINARY_DIR}/deps/couchbase-cxx-client")
+set(COUCHBASE_CXX_SOURCE_DIR "${PROJECT_SOURCE_DIR}/deps/couchbase-cxx-client")
 message(STATUS "COUCHBASE_CXX_BINARY_DIR=${COUCHBASE_CXX_BINARY_DIR}")
+message(STATUS "COUCHBASE_CXX_SOURCE_DIR=${COUCHBASE_CXX_SOURCE_DIR}")
 if(DEFINED COUCHBASE_CXX_CPM_CACHE_DIR AND NOT COUCHBASE_CXX_CPM_CACHE_DIR STREQUAL "")
   file(COPY "${COUCHBASE_CXX_BINARY_DIR}/mozilla-ca-bundle.crt" "${COUCHBASE_CXX_BINARY_DIR}/mozilla-ca-bundle.sha256"
     DESTINATION "${COUCHBASE_CXX_CPM_CACHE_DIR}")
@@ -183,18 +197,33 @@ file(
   "src/management/*.cxx")
 add_library(pycbcc_core SHARED ${SOURCE_FILES})
 
-target_include_directories(pycbcc_core PRIVATE "${CB_CXX_DIR}/include" "${CB_CXX_DIR}/third_party/asio/asio/include")
+target_include_directories(
+  pycbcc_core PRIVATE
+  "${COUCHBASE_CXX_SOURCE_DIR}"
+  "${COUCHBASE_CXX_SOURCE_DIR}/third_party/cxx_function"
+  "${COUCHBASE_CXX_SOURCE_DIR}/third_party/expected/include")
+
+set(COUCHBASE_CXX_CLIENT_TARGET couchbase_cxx_client::couchbase_cxx_client_static)
 
 if(WIN32)
   target_link_libraries(
-    pycbcc_core
-    PRIVATE couchbase_cxx_client
-            ${Python3_LIBRARIES}
-            asio
-            Microsoft.GSL::GSL
-            taocpp::json)
+    pycbcc_core PRIVATE
+    ${COUCHBASE_CXX_CLIENT_TARGET}
+    ${Python3_LIBRARIES}
+    asio
+    Microsoft.GSL::GSL
+    taocpp::json
+    fmt::fmt
+    spdlog::spdlog)
 else()
-  target_link_libraries(pycbcc_core PRIVATE couchbase_cxx_client asio Microsoft.GSL::GSL taocpp::json)
+  target_link_libraries(
+    pycbcc_core PRIVATE
+    ${COUCHBASE_CXX_CLIENT_TARGET}
+    asio
+    Microsoft.GSL::GSL
+    taocpp::json
+    fmt::fmt
+    spdlog::spdlog)
   if(APPLE)
     target_link_options(
       pycbcc_core

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,6 +15,8 @@ include deps/couchbase-cxx-cache/cpm/*.cmake
 include deps/couchbase-cxx-cache/asio/*/asio/COPYING
 include deps/couchbase-cxx-cache/asio/*/asio/LICENSE*
 include deps/couchbase-cxx-cache/asio/*/asio/asio/include/*.hpp
+include deps/couchbase-cxx-cache/asio/*/asio/asio/src/asio.cpp
+include deps/couchbase-cxx-cache/asio/*/asio/asio/src/asio_ssl.cpp
 recursive-include deps/couchbase-cxx-cache/asio/*/asio/asio/include/asio *.[hi]pp
 recursive-include deps/couchbase-cxx-cache/boringssl/*/boringssl *.[hcS]
 recursive-include deps/couchbase-cxx-cache/boringssl/*/boringssl *.cc

--- a/couchbase_columnar/protocol/__init__.py
+++ b/couchbase_columnar/protocol/__init__.py
@@ -72,7 +72,7 @@ logging.trace = partial(logging.log, logging.TRACE)  # type: ignore
 
 """
 
-pycbc teardown methods
+pycbcc teardown methods
 
 """
 import atexit  # nopep8 # isort:skip # noqa: E402

--- a/src/client.cxx
+++ b/src/client.cxx
@@ -199,57 +199,22 @@ PyMODINIT_FUNC
 PyInit_pycbcc_core(void)
 {
   Py_Initialize();
-  PyObject* m = nullptr;
-
-  PyObject* result_type;
-  if (pycbcc_result_type_init(&result_type) < 0) {
-    return nullptr;
-  }
-
-  PyObject* core_error_type;
-  if (pycbcc_core_error_type_init(&core_error_type) < 0) {
-    return nullptr;
-  }
-
-  PyObject* columnar_query_iterator_type;
-  if (pycbcc_columnar_query_iterator_type_init(&columnar_query_iterator_type) < 0) {
-    return nullptr;
-  }
-
-  PyObject* pycbcc_logger_type;
-  if (pycbcc_logger_type_init(&pycbcc_logger_type) < 0) {
-    return nullptr;
-  }
-
-  m = PyModule_Create(&pycbcc_core_module);
+  PyObject* m = PyModule_Create(&pycbcc_core_module);
   if (m == nullptr) {
     return nullptr;
   }
 
-  Py_INCREF(result_type);
-  if (PyModule_AddObject(m, "result", result_type) < 0) {
-    Py_DECREF(result_type);
+  if (add_result_objects(m) == nullptr) {
     Py_DECREF(m);
     return nullptr;
   }
 
-  Py_INCREF(core_error_type);
-  if (PyModule_AddObject(m, "core_error", core_error_type) < 0) {
-    Py_DECREF(core_error_type);
+  if (add_exception_objects(m) == nullptr) {
     Py_DECREF(m);
     return nullptr;
   }
 
-  Py_INCREF(columnar_query_iterator_type);
-  if (PyModule_AddObject(m, "columnar_query_iterator", columnar_query_iterator_type) < 0) {
-    Py_DECREF(columnar_query_iterator_type);
-    Py_DECREF(m);
-    return nullptr;
-  }
-
-  Py_INCREF(pycbcc_logger_type);
-  if (PyModule_AddObject(m, "pycbcc_logger", pycbcc_logger_type) < 0) {
-    Py_DECREF(pycbcc_logger_type);
+  if (add_logger_objects(m) == nullptr) {
     Py_DECREF(m);
     return nullptr;
   }

--- a/src/client.hxx
+++ b/src/client.hxx
@@ -236,7 +236,3 @@ add_core_enums(PyObject* module);
 
 void
 add_constants(PyObject* module);
-
-extern PyTypeObject result_type;
-extern PyTypeObject core_error_type;
-extern PyTypeObject columnar_query_iterator_type;

--- a/src/columnar_query.cxx
+++ b/src/columnar_query.cxx
@@ -306,11 +306,9 @@ handle_columnar_query([[maybe_unused]] PyObject* self, PyObject* args, PyObject*
   if (PyErr_Occurred()) {
     return nullptr;
   }
-
   Py_XINCREF(pyObj_callback);
   Py_XINCREF(pyObj_row_callback);
 
-  couchbase::core::columnar::agent agent{ conn->io_, { { conn->cluster_ } } };
   tl::expected<std::shared_ptr<couchbase::core::pending_operation>,
                couchbase::core::columnar::error>
     resp;

--- a/src/exceptions.hxx
+++ b/src/exceptions.hxx
@@ -77,9 +77,6 @@ struct core_error {
   PyObject_HEAD PyObject* error_details = nullptr;
 };
 
-int
-pycbcc_core_error_type_init(PyObject** ptr);
-
 core_error*
 create_core_error_obj();
 
@@ -104,3 +101,6 @@ pycbcc_set_python_exception(CoreClientErrors::ErrorCode client_error_code,
 
 PyObject*
 build_exception(PyObject* self, PyObject* args);
+
+PyObject*
+add_exception_objects(PyObject* pyObj_module);

--- a/src/logger.hxx
+++ b/src/logger.hxx
@@ -223,5 +223,5 @@ struct pycbcc_logger {
   PyObject_HEAD std::shared_ptr<pycbcc_logger_sink> logger_sink_;
 };
 
-int
-pycbcc_logger_type_init(PyObject** ptr);
+PyObject*
+add_logger_objects(PyObject* pyObj_module);

--- a/src/result.hxx
+++ b/src/result.hxx
@@ -27,9 +27,6 @@ struct result {
   PyObject_HEAD PyObject* dict;
 };
 
-int
-pycbcc_result_type_init(PyObject** ptr);
-
 PyObject*
 create_result_obj();
 
@@ -51,11 +48,11 @@ struct columnar_query_iterator {
   }
 };
 
-int
-pycbcc_columnar_query_iterator_type_init(PyObject** ptr);
-
 PyObject*
 create_columnar_query_iterator_obj(PyObject* pyObj_row_callback);
 
 PyObject*
 get_columnar_query_metadata();
+
+PyObject*
+add_result_objects(PyObject* pyObj_module);


### PR DESCRIPTION
Changes
=======
* Update C++ core
* Update bindings to enable Python 3.12 support
* Remove superfluous columnar agent created for each query execution