### PR TITLE
PYCO-89: Columnar - do not raise QueryOperationCanceledError

### DIFF
--- a/couchbase_columnar/protocol/errors.py
+++ b/couchbase_columnar/protocol/errors.py
@@ -139,7 +139,10 @@ class ErrorMapper:
                 client_err_class = PYCBCC_CLIENT_ERROR_MAP.get(cast(int, err_code))
                 if client_err_class is None:
                     return InternalSDKError(f'Unable to match error to client_error_code={err_code}')
-                return client_err_class(err_details.get('message'))
+                err = client_err_class(err_details.get('message'))
+                if isinstance(err, QueryOperationCanceledError):
+                    return ColumnarError(base=err)
+                return err
 
             # Handle C++ core errors
             if 'core_error_code' in err_details:

--- a/couchbase_columnar/protocol/query.py
+++ b/couchbase_columnar/protocol/query.py
@@ -184,7 +184,7 @@ class _QueryStreamingExecutor(StreamingExecutor):
                 self.cancel()
 
         res = self._query_res_ft.result()
-        if isinstance(res, QueryOperationCanceledError):
+        if isinstance(res, ColumnarError) and isinstance(res._base, QueryOperationCanceledError):
             pass
         elif isinstance(res, Exception):
             raise res


### PR DESCRIPTION
Motivation
==========
QueryOperationCanceledError is an internal error the SDK uses to help track client-side query cancelation. It is also used by the C++ core when a socket is closed unexpectedly.  When this occurs we should return a ColumnarError instead of the QueryOperationCanceledError.

Changes
=======
* Wrap QueryOperationCanceledError in ColumnarError