### PR TITLE
PYCO-90: Columnar - Improve ColumnarError repr

### DIFF
--- a/couchbase_columnar/common/errors.py
+++ b/couchbase_columnar/common/errors.py
@@ -15,10 +15,16 @@
 
 from __future__ import annotations
 
+import sys
 from typing import (Dict,
                     Optional,
                     Union,
                     cast)
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 """
 
@@ -45,9 +51,15 @@ class ColumnarError(Exception):
         if self._message is not None and not self._message.isspace():
             details['message'] = self._message
 
+        # if the class instance is a child class, we only need to return the details (if the exist)
+        if isinstance(self, ColumnarError) and type(self) is ColumnarError:
+            class_name = type(self).__name__
+        else:
+            class_name = ''
+
         if details:
-            return f'{type(self).__name__}({details})'
-        return f'{type(self).__name__}()'
+            return f'{class_name}({details})' if class_name else f'{details}'
+        return f'{class_name}()' if class_name else '()'
 
     def __str__(self) -> str:
         return self.__repr__()
@@ -156,3 +168,9 @@ class QueryOperationCanceledError(Exception):
 
     def __str__(self) -> str:
         return self.__repr__()
+
+
+ColumnarErrors: TypeAlias = Union[ColumnarError,
+                                  InvalidCredentialError,
+                                  QueryError,
+                                  TimeoutError]

--- a/couchbase_columnar/protocol/errors.py
+++ b/couchbase_columnar/protocol/errors.py
@@ -30,6 +30,7 @@ else:
 
 from couchbase_columnar.common.core.utils import is_null_or_empty
 from couchbase_columnar.common.errors import (ColumnarError,
+                                              ColumnarErrors,
                                               InternalSDKError,
                                               QueryOperationCanceledError)
 from couchbase_columnar.protocol.pycbcc_core import core_error
@@ -113,7 +114,7 @@ class ClientErrorMap(Enum):
     InternalSDKError = 4
 
 
-PYCBCC_CORE_ERROR_MAP: Dict[int, type[ColumnarError]] = {
+PYCBCC_CORE_ERROR_MAP: Dict[int, type[ColumnarErrors]] = {
     e.value: getattr(sys.modules['couchbase_columnar.common.errors'], e.name) for e in CoreErrorMap
 }
 
@@ -129,8 +130,8 @@ class ErrorMapper:
     @staticmethod  # noqa: C901
     def build_error(core_error: CoreColumnarError,
                     mapping: Optional[Dict[str, type[ColumnarError]]] = None
-                    ) -> Union[ColumnarError, ClientError]:
-        err_class: Optional[type[ColumnarError]] = None
+                    ) -> Union[ColumnarErrors, ClientError]:
+        err_class: Optional[type[ColumnarErrors]] = None
         err_details = core_error.error_details
         if err_details is not None:
             # Handle client errors from the CPython bindings


### PR DESCRIPTION
Motivation
==========
Currently when exceptions are printed out, there is a duplication of the error name (e.g. InvalidCredentialError(InvalidCredentialError(...))). A small, but nice improvement would be to remove this duplication.

Changes
=======
* Update ColumnarError __repr__ to not include the class name if the error is a child instance of ColumnarError
* Add ColumnarErrors TypeAlias